### PR TITLE
Create config files hash entry on site creation for php site type

### DIFF
--- a/src/PHP.php
+++ b/src/PHP.php
@@ -6,6 +6,7 @@ namespace EE\Site\Type;
 
 use EE;
 use EE\Model\Site;
+use EE\Model\ConfigHash;
 use Symfony\Component\Filesystem\Filesystem;
 use function EE\Site\Utils\auto_site_name;
 use function EE\Site\Utils\get_site_info;
@@ -787,6 +788,13 @@ class PHP extends EE_Site_Command {
 		try {
 			if ( Site::create( $data ) ) {
 				\EE::log( 'Site entry created.' );
+
+				// Get site config files.
+				$files = ConfigHash::get_files_in_path( $this->site_data['site_fs_path'] );
+
+				// Create entries for sites' configuration files.
+				ConfigHash::insert_hash_data( $files, $this->site_data['site_url'] );
+
 			} else {
 				throw new \Exception( 'Error creating site entry in database.' );
 			}

--- a/src/PHP.php
+++ b/src/PHP.php
@@ -789,11 +789,8 @@ class PHP extends EE_Site_Command {
 			if ( Site::create( $data ) ) {
 				\EE::log( 'Site entry created.' );
 
-				// Get site config files.
-				$files = ConfigHash::get_files_in_path( $this->site_data['site_fs_path'] );
-
 				// Create entries for sites' configuration files.
-				ConfigHash::insert_hash_data( $files, $this->site_data['site_url'] );
+				ConfigHash::create_site_config_hash( $this->site_data['site_fs_path'], $this->site_data['site_url'] );
 
 			} else {
 				throw new \Exception( 'Error creating site entry in database.' );


### PR DESCRIPTION
Fixes EasyEngine/site-command#291
Depends on EasyEngine/easyengine#1373