### PR TITLE
Fix admin-email flag typo

### DIFF
--- a/src/PHP.php
+++ b/src/PHP.php
@@ -297,7 +297,7 @@ class PHP extends EE_Site_Command {
 				$this->site_data['db_port'] = empty( $arg_host_port[1] ) ? '3306' : $arg_host_port[1];
 			}
 		}
-		$this->site_data['app_admin_email'] = \EE\Utils\get_flag_value( $assoc_args, 'admin_email', strtolower( 'admin@' . $this->site_data['site_url'] ) );
+		$this->site_data['app_admin_email'] = \EE\Utils\get_flag_value( $assoc_args, 'admin-email', strtolower( 'admin@' . $this->site_data['site_url'] ) );
 		$this->skip_status_check            = \EE\Utils\get_flag_value( $assoc_args, 'skip-status-check' );
 		$this->force                        = \EE\Utils\get_flag_value( $assoc_args, 'force' );
 


### PR DESCRIPTION
The flag for admin-email in site-type-wp is mistyped as `admin_email` instead of `admin-email`. This PR aims to fix that.