### PR TITLE
feat(PHP): update default PHP version to 8.3

### DIFF
--- a/src/PHP.php
+++ b/src/PHP.php
@@ -83,7 +83,7 @@ class PHP extends EE_Site_Command {
 	 * [--php=<php-version>]
 	 * : PHP version for site. Currently only supports PHP 5.6, 7.0, 7.2, 7.3, 7.4, 8.0, 8.1, 8.2, 8.3, 8.4 and latest.
 	 * ---
-	 * default: latest
+	 * default: 8.3
 	 * options:
 	 *	- 5.6
 	 *	- 7.0
@@ -239,7 +239,7 @@ class PHP extends EE_Site_Command {
 				$this->site_data['php_version'] = 7.4;
 				$old_version                    .= ' yet';
 			} elseif ( 8 === $floor ) {
-				$this->site_data['php_version'] = 8.2;
+				$this->site_data['php_version'] = 8.3;
 				$old_version                    .= ' yet';
 			} else {
 				EE::error( 'Unsupported PHP version: ' . $this->site_data['php_version'] );

--- a/src/Site_PHP_Docker.php
+++ b/src/Site_PHP_Docker.php
@@ -65,7 +65,7 @@ class Site_PHP_Docker {
 			$db['networks']     = $network_default;
 		}
 		// PHP configuration.
-		$php_image_key = ( 'latest' === $filters['php_version'] ? 'easyengine/php8.2' : 'easyengine/php' . $filters['php_version'] );
+		$php_image_key = ( 'latest' === $filters['php_version'] ? 'easyengine/php8.3' : 'easyengine/php' . $filters['php_version'] );
 
 		$php['service_name'] = [ 'name' => 'php' ];
 		$php['image']        = [ 'name' => $php_image_key . ':' . $img_versions[ $php_image_key ] ];


### PR DESCRIPTION
This pull request updates the default PHP version used in the application from 8.2 to 8.3. The changes ensure that new sites and Docker configurations will use PHP 8.3 by default, improving compatibility with the latest PHP features and security updates.

**Default PHP version updates:**

* Changed the default PHP version in the `__construct` method of `src/PHP.php` from `latest` to `8.3`, clarifying the default for site creation.
* Updated the logic in the `create` method of `src/PHP.php` so that when the minimum supported version is 8, it now sets `php_version` to `8.3` instead of `8.2`.

**Docker configuration update:**

* Modified the PHP Docker image selection in `generate_docker_compose_yml` in `src/Site_PHP_Docker.php` to use `easyengine/php8.3` when the PHP version is set to `latest`.