### PR TITLE
fix(php): remove stale PHP version fallbacks

### DIFF
--- a/src/PHP.php
+++ b/src/PHP.php
@@ -198,7 +198,7 @@ class PHP extends EE_Site_Command {
 		$this->site_data['site_fs_path']      = WEBROOT . $this->site_data['site_url'];
 		$this->cache_type                     = \EE\Utils\get_flag_value( $assoc_args, 'cache' );
 		$this->site_data['site_ssl_wildcard'] = \EE\Utils\get_flag_value( $assoc_args, 'wildcard' );
-		$this->site_data['php_version']       = \EE\Utils\get_flag_value( $assoc_args, 'php', 'latest' );
+		$this->site_data['php_version']       = \EE\Utils\get_flag_value( $assoc_args, 'php' );
 		$this->site_data['app_sub_type']      = 'php';
 
 		$this->site_data['site_container_fs_path'] = get_public_dir( $assoc_args );
@@ -247,8 +247,6 @@ class PHP extends EE_Site_Command {
 			}
 			\EE::confirm( sprintf( 'EEv4 does not support PHP %s. Continue with PHP %s?', $old_version, $this->site_data['php_version'] ) );
 		}
-
-		$this->site_data['php_version'] = ( 8.0 === (double) $this->site_data['php_version'] ) ? 'latest' : $this->site_data['php_version'];
 
 		if ( $this->cache_type && ! $local_cache ) {
 			\EE\Service\Utils\init_global_container( GLOBAL_REDIS );


### PR DESCRIPTION
## Summary

Mirrors the PHP version cleanup done in `site-type-wp`. **The default is already PHP 8.4** here — PR #110 (php-fpm 8.5 support) correctly bumped the `--php` synopsis `default:` to `8.4`, and EE injects that into the args before `create()` runs. This PR removes two leftovers from earlier defaults that were dead or actively wrong.

## Changes

**1. Drop the dead `'latest'` fallback (`PHP.php:201`)**

```php
- $this->site_data['php_version'] = \EE\Utils\get_flag_value( $assoc_args, 'php', 'latest' );
+ $this->site_data['php_version'] = \EE\Utils\get_flag_value( $assoc_args, 'php' );
```

The synopsis `default: 8.4` is always populated into `$assoc_args['php']` before the command runs, so the `'latest'` fallback never executed. It only served to confuse and drift from the real default — same dead code that was removed from `site-type-wp`.

**2. Remove the stale `8.0 → 'latest'` remap (`PHP.php:251`)**

```php
- $this->site_data['php_version'] = ( 8.0 === (double) $this->site_data['php_version'] ) ? 'latest' : $this->site_data['php_version'];
```

This dated back to when `8.0` was the latest image. With `latest` now resolving to `easyengine/php8.4`, the remap silently rewrote an explicit **`--php=8.0`** request to `'latest'` → the **php8.4** image. Removing it ensures an explicitly requested version is always honoured. `site-type-wp` removed its equivalent line in the "Scrape latest in php version entry" change; this repo never got that cleanup.

## Behaviour

| Invocation | Before | After |
|------------|--------|-------|
| (no `--php`) | 8.4 | 8.4 (unchanged) |
| `--php=latest` | php8.4 image | php8.4 image (unchanged) |
| `--php=8.0` | **silently → php8.4** | **php8.0** (fixed) |

No change for the default or `latest`; the only behavioural difference is that `--php=8.0` is now honoured instead of being rewritten.
