### PR TITLE
refactor(php): centralize the default PHP version into a single constant

### DIFF
--- a/src/PHP.php
+++ b/src/PHP.php
@@ -107,7 +107,7 @@ class PHP extends EE_Site_Command {
 	 *	- 8.2
 	 *	- 8.3
 	 *	- 8.4
-	 *  - 8.5
+	 *	- 8.5
 	 *	- latest
 	 * ---
 	 *
@@ -243,7 +243,7 @@ class PHP extends EE_Site_Command {
 		$this->site_data['alias_domains'] = substr( $this->site_data['alias_domains'], 0, - 1 );
 
 		$supported_php_versions = self::SUPPORTED_PHP_VERSIONS;
-		if ( ! in_array( $this->site_data['php_version'], $supported_php_versions ) ) {
+		if ( ! in_array( $this->site_data['php_version'], $supported_php_versions, true ) ) {
 			$old_version = $this->site_data['php_version'];
 			$floor       = (int) floor( $this->site_data['php_version'] );
 			if ( 5 === $floor ) {

--- a/src/PHP.php
+++ b/src/PHP.php
@@ -27,6 +27,19 @@ use function EE\Utils\get_value_if_flag_isset;
 class PHP extends EE_Site_Command {
 
 	/**
+	 * Default PHP version for new sites. Single source of truth: this is also
+	 * the version the `latest` image tag resolves to and the 8.x fallback for
+	 * unsupported requests. Change this one constant to move the default.
+	 */
+	const DEFAULT_PHP_VERSION = '8.4';
+
+	/**
+	 * All PHP versions EasyEngine ships images for. Keep in sync with the
+	 * `--php` options list in the create() docblock.
+	 */
+	const SUPPORTED_PHP_VERSIONS = [ '5.6', '7.0', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5', 'latest' ];
+
+	/**
 	 * @var string $cache_type Type of caching being used.
 	 */
 	private $cache_type;
@@ -83,7 +96,6 @@ class PHP extends EE_Site_Command {
 	 * [--php=<php-version>]
 	 * : PHP version for site. Currently only supports PHP 5.6, 7.0, 7.2, 7.3, 7.4, 8.0, 8.1, 8.2, 8.3, 8.4, 8.5, and latest.
 	 * ---
-	 * default: 8.4
 	 * options:
 	 *	- 5.6
 	 *	- 7.0
@@ -198,7 +210,7 @@ class PHP extends EE_Site_Command {
 		$this->site_data['site_fs_path']      = WEBROOT . $this->site_data['site_url'];
 		$this->cache_type                     = \EE\Utils\get_flag_value( $assoc_args, 'cache' );
 		$this->site_data['site_ssl_wildcard'] = \EE\Utils\get_flag_value( $assoc_args, 'wildcard' );
-		$this->site_data['php_version']       = \EE\Utils\get_flag_value( $assoc_args, 'php' );
+		$this->site_data['php_version']       = \EE\Utils\get_flag_value( $assoc_args, 'php', self::DEFAULT_PHP_VERSION );
 		$this->site_data['app_sub_type']      = 'php';
 
 		$this->site_data['site_container_fs_path'] = get_public_dir( $assoc_args );
@@ -230,7 +242,7 @@ class PHP extends EE_Site_Command {
 		}
 		$this->site_data['alias_domains'] = substr( $this->site_data['alias_domains'], 0, - 1 );
 
-		$supported_php_versions = [ 5.6, 7.0, 7.2, 7.3, 7.4, 8.0, 8.1, 8.2, 8.3, 8.4, 8.5, 'latest' ];
+		$supported_php_versions = self::SUPPORTED_PHP_VERSIONS;
 		if ( ! in_array( $this->site_data['php_version'], $supported_php_versions ) ) {
 			$old_version = $this->site_data['php_version'];
 			$floor       = (int) floor( $this->site_data['php_version'] );
@@ -240,7 +252,7 @@ class PHP extends EE_Site_Command {
 				$this->site_data['php_version'] = 7.4;
 				$old_version                    .= ' yet';
 			} elseif ( 8 === $floor ) {
-				$this->site_data['php_version'] = 8.4;
+				$this->site_data['php_version'] = self::DEFAULT_PHP_VERSION;
 				$old_version                    .= ' yet';
 			} else {
 				EE::error( 'Unsupported PHP version: ' . $this->site_data['php_version'] );

--- a/src/Site_PHP_Docker.php
+++ b/src/Site_PHP_Docker.php
@@ -65,7 +65,7 @@ class Site_PHP_Docker {
 			$db['networks']     = $network_default;
 		}
 		// PHP configuration.
-		$php_image_key = ( 'latest' === $filters['php_version'] ? 'easyengine/php8.4' : 'easyengine/php' . $filters['php_version'] );
+		$php_image_key = ( 'latest' === $filters['php_version'] ? 'easyengine/php' . PHP::DEFAULT_PHP_VERSION : 'easyengine/php' . $filters['php_version'] );
 
 		$php['service_name'] = [ 'name' => 'php' ];
 		$php['image']        = [ 'name' => $php_image_key . ':' . $img_versions[ $php_image_key ] ];


### PR DESCRIPTION
## Summary

Centralizes the PHP version into a single source of truth so a default bump is a one-line edit. Mirrors the same change in site-type-wp (EasyEngine/site-type-wp#238).

Introduces two class constants on `PHP`:

```php
const DEFAULT_PHP_VERSION    = '8.4';
const SUPPORTED_PHP_VERSIONS = [ '5.6', …, '8.5', 'latest' ];
```

The default `8.4` was previously hardcoded **independently** in three spots; all now read `DEFAULT_PHP_VERSION`:

| Consumer | Before | After |
|----------|--------|-------|
| Default when `--php` omitted | docblock `default: 8.4` | `get_flag_value( …, 'php', self::DEFAULT_PHP_VERSION )` |
| 8.x unsupported-version fallback | `= 8.4;` | `= self::DEFAULT_PHP_VERSION;` |
| `latest` → image tag (`Site_PHP_Docker`) | `'easyengine/php8.4'` | `'easyengine/php' . PHP::DEFAULT_PHP_VERSION` |

The inline `$supported_php_versions` array is replaced by `SUPPORTED_PHP_VERSIONS`.

### Why removing the docblock `default:` works
EE injects a docblock `default:` into `$assoc_args` *before* `create()` runs, so a docblock default would always win over the constant. Removing it lets the `get_flag_value()` fallback supply `DEFAULT_PHP_VERSION` when `--php` is omitted — making the constant authoritative. Effective default is unchanged (8.4).

### Also included
- **String version literals** instead of floats — fixes a latent bug where an `x.0` version stringifies to `"8"` in the image name (`'easyengine/php' . 8.0` → `easyengine/php8`).

## Notes / tradeoffs for reviewers

- **`--help` no longer prints `default: 8.4`** for `--php` (the options list still shows). Inherent cost of single-sourcing the default in code. Alternative: keep the docblock `default:` and add a test asserting it equals the constant (drift-proof, but a bump becomes two edits).
- **README regeneration:** `default:` is gone from the docblock, so `ee scaffold package-readme` will no longer emit the `default: 8.4` line that #112 added. Coordinate a README regen after merge (or keep the docblock default per the point above).
- **Irreducible duplication:** the docblock `options:` list and prose still enumerate versions (PHPDoc can't reference a constant), so adding a *new* version still touches the docblock + `SUPPORTED_PHP_VERSIONS`. A synopsis↔constant guard test would make that drift-proof — happy to add it.
